### PR TITLE
function configure_spacy_model

### DIFF
--- a/pyabsa/core/apc/dataset_utils/apc_utils.py
+++ b/pyabsa/core/apc/dataset_utils/apc_utils.py
@@ -395,6 +395,7 @@ def configure_spacy_model(opt):
             nlp = spacy.load(opt.spacy_model)
         except:
             raise RuntimeError('Download failed, you can download {} manually.'.format(opt.spacy_model))
+    return nlp
 
 
 def calculate_dep_dist(sentence, aspect):


### PR DESCRIPTION
allow nlp return from function configure_spacy_model, then we can use it anywhere we like

for exmaple:

```
from pyabsa.functional.config.apc_config_manager import APCConfigManager
from pyabsa.functional.config.apc_config_manager import _apc_config_english
from pyabsa.core.apc.dataset_utils.apc_utils import configure_spacy_model

_apc_config_english.update({'spacy_model': 'en_core_web_md'})
nlp = configure_spacy_model(APCConfigManager.get_apc_config_english())
```
